### PR TITLE
Add link for version 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ https://www.pik-potsdam.de/paris-reality-check/primap-hist/
 
 | Version | Link                                 |
 | :-----: | ------------------------------------ |
-| 2.1 beta2   | email johannes.guetschow@pik-potsdam.de  |
+| 2.1     | https://doi.org/10.5880/PIK.2019.018  |
 | 2.0     | https://doi.org/10.5880/PIK.2019.001 |
 | 1.2     | https://doi.org/10.5880/PIK.2018.003 |
 | 1.1     | https://doi.org/10.5880/PIK.2017.001 |


### PR DESCRIPTION
I just noticed that the link for version 2.1 is missing, and corrected that.